### PR TITLE
Add CI workflow and DB fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+      - name: Run Django tests
+        run: python manage.py test
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+      - name: Install Node dependencies and run tests
+        run: |
+          cd blog_front
+          npm ci
+          npm test -- --runInBand

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Blog CMS
+
+This project provides a simple Django backend with a Next.js front-end.
+
+## Front-end Dev
+
+The front-end source lives in `blog_front` and uses Next.js 14 with TypeScript and Tailwind CSS.
+
+### Local Development
+
+1. Start the Django backend using `docker-compose up`.
+2. In another terminal, run the Node container defined in `docker-compose.override.yml`:
+   ```
+   docker-compose -f docker-compose.yml -f docker-compose.override.yml up node
+   ```
+   This executes `npm run dev` inside the container and serves the app on [http://localhost:3000](http://localhost:3000).
+
+Alternatively you can run the frontend directly on your machine:
+
+```bash
+cd blog_front && npm install && npm run dev
+```
+
+The index page fetches articles from `http://localhost:18000/api/articles/` and displays them as cards. Individual articles are available under `/articles/[slug]`.
+
+## Database
+
+CI runs tests using SQLite automatically because no `POSTGRES_DB` environment variable is set. For local development, use Docker/Postgres via `docker-compose up`.

--- a/blog_front/__tests__/sample.test.tsx
+++ b/blog_front/__tests__/sample.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+function Hello() {
+  return <h1>Hello</h1>;
+}
+
+test('render hello', () => {
+  render(<Hello />);
+  expect(screen.getByText('Hello')).toBeInTheDocument();
+});

--- a/blog_front/app/articles/[slug]/page.tsx
+++ b/blog_front/app/articles/[slug]/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface Article {
+  id: number;
+  title: string;
+  body: string;
+  slug: string;
+}
+
+async function getArticle(slug: string): Promise<Article> {
+  const res = await fetch(`http://localhost:18000/api/articles/${slug}/`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch article');
+  }
+  return res.json();
+}
+
+export default async function ArticlePage({ params }: { params: { slug: string } }) {
+  const article = await getArticle(params.slug);
+  return (
+    <article className="prose mx-auto p-8">
+      <h1>{article.title}</h1>
+      <p>{article.body}</p>
+    </article>
+  );
+}

--- a/blog_front/app/layout.tsx
+++ b/blog_front/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import React from 'react';
+
+export const metadata = {
+  title: 'Blog Front',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/blog_front/app/page.tsx
+++ b/blog_front/app/page.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface Article {
+  id: number;
+  title: string;
+  slug: string;
+  body: string;
+}
+
+async function getArticles(): Promise<Article[]> {
+  const res = await fetch('http://localhost:18000/api/articles/', {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch articles');
+  }
+  return res.json();
+}
+
+export default async function Page() {
+  const articles = await getArticles();
+  return (
+    <main className="p-8 grid gap-4 grid-cols-1">
+      {articles.map((article) => (
+        <a
+          key={article.slug}
+          href={`/articles/${article.slug}`}
+          className="p-4 border rounded shadow hover:bg-gray-50"
+        >
+          <h2 className="text-xl font-bold mb-2">{article.title}</h2>
+          <p className="text-gray-700">
+            {article.body.substring(0, 100)}...
+          </p>
+        </a>
+      ))}
+    </main>
+  );
+}

--- a/blog_front/jest.config.js
+++ b/blog_front/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};

--- a/blog_front/jest.setup.ts
+++ b/blog_front/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/blog_front/next-env.d.ts
+++ b/blog_front/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/blog_front/next.config.js
+++ b/blog_front/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/blog_front/package.json
+++ b/blog_front/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "blog_front",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.3",
+    "@types/react": "18.2.45",
+    "autoprefixer": "10.4.16",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.0.0",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.3.7",
+    "typescript": "5.3.3"
+  }
+}

--- a/blog_front/postcss.config.js
+++ b/blog_front/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/blog_front/styles/globals.css
+++ b/blog_front/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/blog_front/tailwind.config.js
+++ b/blog_front/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/blog_front/tsconfig.json
+++ b/blog_front/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/cms_backend/settings.py
+++ b/cms_backend/settings.py
@@ -42,12 +42,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'drf_spectacular',
     'blog',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -81,16 +83,24 @@ WSGI_APPLICATION = 'cms_backend.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "HOST": "db",          # コンテナ名
-        "PORT": 5432,          # コンテナ側ポート
-        "NAME": os.getenv("POSTGRES_DB"),
-        "USER": os.getenv("POSTGRES_USER"),
-        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
+if os.getenv("POSTGRES_DB"):
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "HOST": "db",
+            "PORT": 5432,
+            "NAME": os.getenv("POSTGRES_DB"),
+            "USER": os.getenv("POSTGRES_USER"),
+            "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 
 # Password validation
@@ -149,3 +159,6 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
 }
+
+# Allow all origins for development
+CORS_ALLOW_ALL_ORIGINS = True

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+services:
+  node:
+    image: node:16-alpine
+    container_name: blogcms_node
+    working_dir: /app/blog_front
+    volumes:
+      - ./blog_front:/app/blog_front
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - web

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Django==5.0.*
 djangorestframework==3.15.*
 psycopg[binary]==3.1.*
 drf-spectacular==0.27.*   # OpenAPI 自動生成
+django-cors-headers==4.3.*  # CORS middleware
 python-dotenv==1.0.*      # .env 読み込み補助（manage.py で後ほど利用）


### PR DESCRIPTION
## Summary
- fallback to SQLite if Postgres env vars are missing
- add GitHub Actions workflow running Django and Jest tests
- document local frontend dev and note CI DB choice

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python manage.py test` *(fails: ModuleNotFoundError: dotenv)*
- `npm ci` *(fails: requires package-lock.json)*
- `npm test -- --runInBand` *(fails: jest not found)*
