### PR TITLE
Add Next.js frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ work ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt python-dotenv
+      - name: Run Django tests
+        run: python manage.py test
+      - name: Install Node dependencies and run tests
+        run: |
+          cd blog_front
+          npm install
+          npm test -- --runInBand
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        args: [--check, --diff]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.6
+    hooks:
+      - id: ruff
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Blog CMS
+
+This project provides a simple Django backend with a Next.js front-end.
+
+## Front-end Dev
+
+The front-end source lives in `blog_front` and uses Next.js 14 with TypeScript and Tailwind CSS.
+
+### Local Development
+
+1. Start the Django backend using `docker-compose up`.
+2. In another terminal, run the Node container defined in `docker-compose.override.yml`:
+   ```
+   docker-compose -f docker-compose.yml -f docker-compose.override.yml up node
+   ```
+   This executes `npm run dev` inside the container and serves the app on [http://localhost:3000](http://localhost:3000).
+
+The index page fetches articles from `http://localhost:18000/api/articles/` and displays them as cards. Individual articles are available under `/articles/[slug]`.

--- a/blog/apps.py
+++ b/blog/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class BlogConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'blog'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "blog"

--- a/blog/models.py
+++ b/blog/models.py
@@ -33,7 +33,9 @@ class Article(models.Model):
     title = models.CharField(max_length=200)
     slug = models.SlugField(max_length=220, unique=True, blank=True)
     author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    category = models.ForeignKey(Category, on_delete=models.PROTECT, related_name="articles")
+    category = models.ForeignKey(
+        Category, on_delete=models.PROTECT, related_name="articles"
+    )
     tags = models.ManyToManyField(Tag, blank=True, related_name="articles")
     body = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)
@@ -50,4 +52,3 @@ class Article(models.Model):
 
     def __str__(self):
         return self.title
-

--- a/blog/serializers.py
+++ b/blog/serializers.py
@@ -58,5 +58,3 @@ class ArticleSerializer(serializers.ModelSerializer):
         if tags is not None:
             instance.tags.set(tags)
         return instance
-
-　

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -11,4 +11,3 @@ router.register(r"articles", ArticleViewSet)
 urlpatterns = [
     path("", include(router.urls)),
 ]
-

--- a/blog/views.py
+++ b/blog/views.py
@@ -28,10 +28,11 @@ class TagViewSet(viewsets.ModelViewSet):
 
 
 class ArticleViewSet(viewsets.ModelViewSet):
-    queryset = Article.objects.select_related("author", "category").prefetch_related("tags")
+    queryset = Article.objects.select_related("author", "category").prefetch_related(
+        "tags"
+    )
     serializer_class = ArticleSerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsAuthorOrReadOnly]
 
     def perform_create(self, serializer):
         serializer.save(author=self.request.user)
-

--- a/blog_front/__tests__/sample.test.tsx
+++ b/blog_front/__tests__/sample.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+function Hello() {
+  return <h1>Hello</h1>;
+}
+
+test('render hello', () => {
+  render(<Hello />);
+  expect(screen.getByText('Hello')).toBeInTheDocument();
+});

--- a/blog_front/app/articles/[slug]/page.tsx
+++ b/blog_front/app/articles/[slug]/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface Article {
+  id: number;
+  title: string;
+  body: string;
+  slug: string;
+}
+
+async function getArticle(slug: string): Promise<Article> {
+  const res = await fetch(`http://localhost:18000/api/articles/${slug}/`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch article');
+  }
+  return res.json();
+}
+
+export default async function ArticlePage({ params }: { params: { slug: string } }) {
+  const article = await getArticle(params.slug);
+  return (
+    <article className="prose mx-auto p-8">
+      <h1>{article.title}</h1>
+      <p>{article.body}</p>
+    </article>
+  );
+}

--- a/blog_front/app/layout.tsx
+++ b/blog_front/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import React from 'react';
+
+export const metadata = {
+  title: 'Blog Front',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/blog_front/app/page.tsx
+++ b/blog_front/app/page.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface Article {
+  id: number;
+  title: string;
+  slug: string;
+  body: string;
+}
+
+async function getArticles(): Promise<Article[]> {
+  const res = await fetch('http://localhost:18000/api/articles/', {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch articles');
+  }
+  return res.json();
+}
+
+export default async function Page() {
+  const articles = await getArticles();
+  return (
+    <main className="p-8 grid gap-4 grid-cols-1">
+      {articles.map((article) => (
+        <a
+          key={article.slug}
+          href={`/articles/${article.slug}`}
+          className="p-4 border rounded shadow hover:bg-gray-50"
+        >
+          <h2 className="text-xl font-bold mb-2">{article.title}</h2>
+          <p className="text-gray-700">
+            {article.body.substring(0, 100)}...
+          </p>
+        </a>
+      ))}
+    </main>
+  );
+}

--- a/blog_front/jest.config.js
+++ b/blog_front/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};

--- a/blog_front/jest.setup.ts
+++ b/blog_front/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/blog_front/next-env.d.ts
+++ b/blog_front/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/blog_front/next.config.js
+++ b/blog_front/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/blog_front/package.json
+++ b/blog_front/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "blog_front",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.3",
+    "@types/react": "18.2.45",
+    "autoprefixer": "10.4.16",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.0.0",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.3.7",
+    "typescript": "5.3.3"
+  }
+}

--- a/blog_front/postcss.config.js
+++ b/blog_front/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/blog_front/styles/globals.css
+++ b/blog_front/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/blog_front/tailwind.config.js
+++ b/blog_front/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/blog_front/tsconfig.json
+++ b/blog_front/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/cms_backend/asgi.py
+++ b/cms_backend/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cms_backend.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms_backend.settings")
 
 application = get_asgi_application()

--- a/cms_backend/settings.py
+++ b/cms_backend/settings.py
@@ -42,12 +42,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     'rest_framework',
     'drf_spectacular',
     'blog',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -149,3 +151,6 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
 }
+
+# Allow all origins for development
+CORS_ALLOW_ALL_ORIGINS = True

--- a/cms_backend/urls.py
+++ b/cms_backend/urls.py
@@ -15,8 +15,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-
-
 # cms_backend/urls.py
 from django.contrib import admin
 from django.urls import path, include
@@ -25,7 +23,10 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
+    path(
+        "api/docs/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
     path("api/", include("blog.urls")),  # ★ 追加
 ]
-

--- a/cms_backend/wsgi.py
+++ b/cms_backend/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cms_backend.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms_backend.settings")
 
 application = get_wsgi_application()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+services:
+  node:
+    image: node:16-alpine
+    container_name: blogcms_node
+    working_dir: /app/blog_front
+    volumes:
+      - ./blog_front:/app/blog_front
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - web

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Django==5.0.*
 djangorestframework==3.15.*
 psycopg[binary]==3.1.*
 drf-spectacular==0.27.*   # OpenAPI 自動生成
+django-cors-headers==4.3.*  # CORS middleware
 python-dotenv==1.0.*      # .env 読み込み補助（manage.py で後ほど利用）


### PR DESCRIPTION
## Summary
- add Next.js 14 frontend under `blog_front`
- configure Tailwind CSS and Jest
- add Docker override with Node service
- enable CORS in Django
- document frontend usage
- configure pre-commit and CI
- apply Black formatting

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: dotenv)*
- `npm test -- --runInBand` *(fails: jest not found)*
